### PR TITLE
Fix build error for physical devices.

### DIFF
--- a/SlackTextViewController/Project.swift
+++ b/SlackTextViewController/Project.swift
@@ -20,7 +20,7 @@ let project = Project(name: "SlackTextViewController",
                                ]),
                                settings: Settings(
                                  configurations: [
-                                  .debug(name: "Debug", settings: ["EXCLUDED_ARCHS": "arm64"], xcconfig: "SlackTextViewController.xcconfig"),
+                                  .debug(name: "Debug", settings: ["EXCLUDED_ARCHS[sdk=iphonesimulator*]": "arm64"], xcconfig: "SlackTextViewController.xcconfig"),
                                   .release(name: "Release", xcconfig: "SlackTextViewController.xcconfig")
                                 ]))
                       ])


### PR DESCRIPTION
# Context
We should only exclude arm64 when building for simulator, otherwise building for physical devices won’t work.

App PR: https://github.com/untitledstartup/ios-app/pull/4292