### PR TITLE
CONT-5313: Expose slk_enableTypingSuggestionIfNeeded in the header to be overridable

### DIFF
--- a/Source/SLKTextViewController.h
+++ b/Source/SLKTextViewController.h
@@ -625,6 +625,7 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 - (void)slk_setupViewConstraints;
 - (void)slk_updateViewConstraints;
 - (void)slk_registerNotifications;
+- (void)slk_enableTypingSuggestionIfNeeded;
 @property (nonatomic, strong) NSLayoutConstraint *keyboardHC;
 
 @end


### PR DESCRIPTION
Expose slk_enableTypingSuggestionIfNeeded in the header to be overridable.
I need to override this function in the MN project to avoid a loop when this function calls an update in the SLKTextView, which triggers the show/hide keyboard events.